### PR TITLE
Fix SQL injection risks in backend

### DIFF
--- a/backend/login.php
+++ b/backend/login.php
@@ -12,13 +12,15 @@ if (!$data || !isset($data->email, $data->password)) {
   exit;
 }
 
-$email = $conn->real_escape_string($data->email);
+$email = trim($data->email);
 $password = $data->password;
 
-$sql = "SELECT * FROM usuarios WHERE email = '$email'";
-$result = $conn->query($sql);
+$stmt = $conn->prepare("SELECT nombre, password FROM usuarios WHERE email = ?");
+$stmt->bind_param("s", $email);
+$stmt->execute();
+$result = $stmt->get_result();
 
-if ($result->num_rows === 1) {
+if ($result && $result->num_rows === 1) {
   $user = $result->fetch_assoc();
   if (password_verify($password, $user['password'])) {
     echo json_encode(["status" => "success", "nombre" => $user['nombre']]);
@@ -29,5 +31,6 @@ if ($result->num_rows === 1) {
   echo json_encode(["status" => "error", "message" => "Usuario no encontrado"]);
 }
 
+$stmt->close();
 $conn->close();
 ?>

--- a/backend/register.php
+++ b/backend/register.php
@@ -12,23 +12,31 @@ if (!$data || !isset($data->nombre, $data->email, $data->password)) {
   exit;
 }
 
-$nombre = $conn->real_escape_string($data->nombre);
-$email = $conn->real_escape_string($data->email);
+$nombre = trim($data->nombre);
+$email = trim($data->email);
 $password = password_hash($data->password, PASSWORD_DEFAULT);
 
 // check si el email ya existe
-$check = $conn->query("SELECT id FROM usuarios WHERE email = '$email'");
-if ($check && $check->num_rows > 0) {
+$checkStmt = $conn->prepare("SELECT id FROM usuarios WHERE email = ?");
+$checkStmt->bind_param("s", $email);
+$checkStmt->execute();
+$checkResult = $checkStmt->get_result();
+if ($checkResult && $checkResult->num_rows > 0) {
   echo json_encode(["status" => "error", "message" => "Ese email ya está registrado."]);
+  $checkStmt->close();
   exit;
 }
+$checkStmt->close();
 
-$sql = "INSERT INTO usuarios (nombre, email, password) VALUES ('$nombre', '$email', '$password')";
+$stmt = $conn->prepare("INSERT INTO usuarios (nombre, email, password) VALUES (?, ?, ?)");
+$stmt->bind_param("sss", $nombre, $email, $password);
 
-if ($conn->query($sql)) {
+if ($stmt->execute()) {
   echo json_encode(["status" => "success"]);
 } else {
-  echo json_encode(["status" => "error", "message" => $conn->error]);
+  echo json_encode(["status" => "error", "message" => $stmt->error]);
 }
 
+$stmt->close();
 $conn->close();
+?>


### PR DESCRIPTION
## Summary
- use prepared statements in `backend/login.php`
- use prepared statements in `backend/register.php`

## Testing
- `npm run build` *(fails: vite permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684055fe18dc832f88e02e652277579c