### PR TITLE
Update pricing hover and links

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -86,7 +86,7 @@
   @apply transition-all duration-300 ease-out;
 }
 .card-animated:hover {
-  @apply shadow-2xl -translate-y-1;
+  @apply -translate-y-2 scale-105 shadow-lg shadow-gray-400/60;
 }
 
 /* Estilos para el scrollbar (opcional, mejora estética) */

--- a/src/pages/PreciosPage.jsx
+++ b/src/pages/PreciosPage.jsx
@@ -15,7 +15,7 @@ const pricingPlans = [
       'Soporte Técnico Preferencial por 12 meses',
       '5hs de capacitación presencial (aplica unicamente Rosario) y 1 año de capacitación a distancia parcial. Videollamadas 1v1. '
     ], 
-    popular: true, 
+    popular: false,
     color: 'from-purple-500 to-purple-600', 
     buttonClass: 'bg-yellow-400 hover:bg-yellow-500 text-gray-900' 
   },
@@ -69,11 +69,12 @@ const PreciosPage = () => (
                 </li>
               ))}
             </ul>
-            <Button 
+            <Button
               className={`w-full font-bold btn-animated ${plan.buttonClass}`}
               size="lg"
+              asChild
             >
-              Elegir Plan
+              <Link to="/register">Elegir Plan</Link>
             </Button>
           </div>
         </motion.div>


### PR DESCRIPTION
## Summary
- tweak pricing page hover style
- remove highlight on "Monocaja" plan
- link pricing buttons to register page

## Testing
- `node node_modules/vite/bin/vite.js build` *(fails: esbuild for another platform)*

------
https://chatgpt.com/codex/tasks/task_e_6841f176d8f0832fa9cb368d41a0755b